### PR TITLE
Закомментировал импорт недостающих модулей.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
     "babel-core": "^6.18",
     "babel-eslint": "^7.1",
     "babel-loader": "^6.2",
+    "babel-plugin-css-modules-transform": "^1.1",
     "babel-plugin-transform-dev-warning": "^0.1",
     "babel-plugin-transform-react-constant-elements": "^6.9",
     "babel-plugin-transform-react-inline-elements": "^6.8",
     "babel-plugin-transform-react-remove-prop-types": "^0.2",
     "babel-plugin-transform-replace-object-assign": "^0.2",
-    "babel-plugin-css-modules-transform": "^1.1",
     "babel-plugin-transform-runtime": "^6.15",
     "babel-polyfill": "^6.7.4",
     "babel-preset-es2015": "^6.18",
@@ -53,8 +53,9 @@
     "gulp-uglify": "^2.0",
     "gulp-umd": "^0.2",
     "jasmine": "^2.5",
-    "yuidocjs": "^0.10",
-    "lerna": "2.0.0-beta.30"
+    "lerna": "2.0.0-beta.30",
+    "webpack": "^1.13.3",
+    "yuidocjs": "^0.10"
   },
   "scripts": {
     "build:react-ui": "better-npm-run build:react-ui",

--- a/packages/metadata-react-ui/FrmLogin/src/FrmLogin.js
+++ b/packages/metadata-react-ui/FrmLogin/src/FrmLogin.js
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from "react";
 
 import TabsLogin from './TabsLogin';
-import User from './TabsUser';
+//import User from './TabsUser';
 
 export default class FrmLogin extends Component {
 

--- a/packages/metadata-react-ui/FrmLogin/src/TabsLogin.js
+++ b/packages/metadata-react-ui/FrmLogin/src/TabsLogin.js
@@ -4,7 +4,8 @@ import Paper from 'material-ui/Paper';
 import TextField from 'material-ui/TextField';
 import RaisedButton from 'material-ui/RaisedButton';
 
-import CnnSettings from './CnnSettings';
+// FIXME
+// import CnnSettings from './CnnSettings';
 
 export default class TabsLogin extends Component {
 
@@ -99,7 +100,7 @@ export default class TabsLogin extends Component {
 
             <Tab label="Подключение" value="b">
 
-              <CnnSettings {...props} />
+              {/* <CnnSettings {...props} /> */}
 
             </Tab>
 


### PR DESCRIPTION
Считаю, что лучше импортировать исходные коды компонентов, вместо транспиляции их с помощью babel. Это освобождает от необходимости отдельно запускать их сборку .