### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -38,7 +38,7 @@ npm install                     # install dependencies
 For the browser, include:
 ```html
 <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/npm/font-awesome@latest/css/font-awesome.min.css">
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/combine/npm/metadata-js/dist/dhx_terrace.min.css,npm/metadata-js/dist/metadata.min.css">
+<link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/combine/npm/metadata-js/dist/dhx_terrace.min.css,npm/metadata-js/dist/metadata.min.css">
 <script src="//cdn.jsdelivr.net/combine/npm/moment,npm/alasql,npm/pouchdb,npm/jquery,npm/metadata-js/dist/dhtmlx.min.js,npm/metadata-js/dist/metadata.min.js"></script>
 ```
 

--- a/README.en.md
+++ b/README.en.md
@@ -37,9 +37,9 @@ npm install                     # install dependencies
 
 For the browser, include:
 ```html
-<link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/fontawesome/latest/css/font-awesome.min.css">
-<link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/g/metadata(dhx_terrace.css+metadata.css)">
-<script src="//cdn.jsdelivr.net/g/momentjs,alasql,pouchdb,jquery,metadata(dhtmlx.min.js+metadata.min.js)"></script>
+<link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/npm/font-awesome@latest/css/font-awesome.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/combine/npm/metadata-js/dist/dhx_terrace.min.css,npm/metadata-js/dist/metadata.min.css">
+<script src="//cdn.jsdelivr.net/combine/npm/moment,npm/alasql,npm/pouchdb,npm/jquery,npm/metadata-js/dist/dhtmlx.min.js,npm/metadata-js/dist/metadata.min.js"></script>
 ```
 
 ### Credits


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/metadata-js.

Feel free to ping me if you have any questions regarding this change.