### PR TITLE
_find priority для учета приоритета объектов при поиске

### DIFF
--- a/packages/metadata-core/src/utils.js
+++ b/packages/metadata-core/src/utils.js
@@ -618,6 +618,9 @@ const utils = {
 				}
 			}
 		} else {
+			let find = {
+				priority: -1
+			};
 			for (let i in src) { // ищем по ключам из val
 				const o = src[i];
 				let finded = true;
@@ -627,9 +630,12 @@ const utils = {
 						break;
 					}
 				}
-				if (finded) {
-					return o;
+				if (finded && o['priority'] > find['priority']) {
+					find = o;
 				}
+			}
+			if (find.priority !== -1) {
+				return find;
 			}
 		}
 	},


### PR DESCRIPTION
Минус в том, что поиск не завершается досрочно. Возвращает объект с наибольшим приоритетом среди объектов, подходящих по критерию поиска.