### PR TITLE
fixup! Оптимизация нумерации, чтобы не считал цифры префикса.

### DIFF
--- a/packages/metadata-pouchdb/src/proto.js
+++ b/packages/metadata-pouchdb/src/proto.js
@@ -55,7 +55,7 @@ export default (constructor) => {
 					.then((res) => {
 						if (res.rows.length) {
 							const num0 = res.rows[0].key[2];
-							for (let i = num0.length - 1; i > prefix.length; i--) {
+							for (let i = num0.length - 1; i >= prefix.length; i--) {
 								if (isNaN(parseInt(num0[i])))
 									break;
 								part = num0[i] + part;


### PR DESCRIPTION
Проблема возникла у пользователя, который дошел до 1000 в индексации заказов. В цикле, который разбирает строку с номером из-за строго условия не разбирался старший разряд.
В итоге была распарсена строка `000` вместо `1000` и присвоился номер 0001.
Дальше хуже. Поиск последнего заказа возвращает документ с `1000` и новые заказы создаются опять с 0001.