### PR TITLE
расширение возможностей конструктора отчетов

### DIFF
--- a/src/reporting.js
+++ b/src/reporting.js
@@ -16,8 +16,10 @@ function SpreadsheetDocument(attr, events) {
 
 	this._attr = {
 		orientation: "portrait",
-		title: "",
-		content: document.createElement("DIV")
+    blank: "",
+    head: document.createElement("HEAD"),
+    content: document.createElement("BODY"),
+    title: ""
 	};
 
 	if(attr && typeof attr == "string"){
@@ -45,13 +47,48 @@ function SpreadsheetDocument(attr, events) {
 }
 SpreadsheetDocument.prototype.__define({
 
+  clear_head: {
+    value: function () {
+      while (this._attr.head.firstChild) {
+        this._attr.head.removeChild(this._attr.head.firstChild);
+      }
+    }
+  },
+
 	clear: {
 		value: function () {
 			while (this._attr.content.firstChild) {
 				this._attr.content.removeChild(this._attr.content.firstChild);
 			}
 		}
-	},
+  },
+  
+  /**
+	 * Добавляем элементы в заголовок
+	 */
+  put_head: {
+    value: function (tag, attr) {
+
+      var elm;
+
+      if(tag instanceof HTMLElement){
+        elm = document.createElement(tag.tagName);
+        elm.innerHTML = tag.innerHTML;
+        if(!attr)
+          attr = tag.attributes;
+      }else{
+        elm = document.createElement(tag);
+      }
+
+      if(attr){
+        Object.keys(attr).forEach(function (key) {
+          elm.setAttribute(attr[key].name || key, attr[key].value || attr[key]);
+        });
+      }
+
+      this._attr.head.appendChild(elm);
+    }
+  },
 
 	/**
 	 * Выводит область ячеек в табличный документ
@@ -73,8 +110,8 @@ SpreadsheetDocument.prototype.__define({
 
 			if(attr){
 				Object.keys(attr).forEach(function (key) {
-					if(key == "id" || attr[key].name == "id")
-						return;
+					//if(key == "id" || attr[key].name == "id")
+					//	return;
 					elm.setAttribute(attr[key].name || key, attr[key].value || attr[key]);
 				});
 			}
@@ -222,6 +259,23 @@ SpreadsheetDocument.prototype.__define({
   },
 
   /**
+   * Копирование элемента
+   */
+  copy_element: {
+    value: function(elem) {
+
+      var elm = document.createElement(elem.tagName);
+      elm.innerHTML = elem.innerHTML;
+      var attr = elem.attributes;
+      Object.keys(attr).forEach(function (key) {
+        elm.setAttribute(attr[key].name || key, attr[key].value || attr[key]);
+      });
+    
+      return elm;
+    }
+  },
+
+  /**
    * Показывает отчет в отдельном окне
    */
   print: {
@@ -234,8 +288,10 @@ SpreadsheetDocument.prototype.__define({
           $p.injected_data['view_blank.html'] = new Blob([$p.injected_data['view_blank.html']], {type: 'text/html'});
         }
 
+        var blob = this.blank ? (new Blob([this.blank], {type: 'text/html'})) : $p.injected_data['view_blank.html'];
+
         var doc = this,
-          url = window.URL.createObjectURL($p.injected_data['view_blank.html']),
+          url = window.URL.createObjectURL(blob),
           wnd_print = window.open(
           url, "_blank", "fullscreen,menubar=no,toolbar=no,location=no,status=no,directories=no,resizable=yes,scrollbars=yes");
 
@@ -246,7 +302,14 @@ SpreadsheetDocument.prototype.__define({
 
         wnd_print.onload = function(e) {
           window.URL.revokeObjectURL(url);
-          wnd_print.document.body.appendChild(doc.content);
+          // копируем элементы из head
+          for (var i = 0; i < doc.head.children.length; i++) {
+            wnd_print.document.head.appendChild(doc.copy_element(doc.head.children[i]));
+          }
+          // копируем элементы из content
+          for (var i = 0; i < doc.content.children.length; i++) {
+            wnd_print.document.body.appendChild(doc.copy_element(doc.content.children[i]));
+          }
           if(doc.title){
             wnd_print.document.title = doc.title;
           }
@@ -265,6 +328,100 @@ SpreadsheetDocument.prototype.__define({
             "Ошибка открытия окна печати<br />Вероятно, в браузере заблокированы всплывающие окна" : err.message
         });
       }
+    }
+  },
+
+  /**
+   * Сохраняет отчет в файл
+   */
+  save_as: {
+    value: function (filename) {
+
+      try{
+
+        if (!($p.injected_data['view_blank.html'] instanceof Blob)){
+          $p.injected_data['view_blank.html'] = new Blob([$p.injected_data['view_blank.html']], {type: 'text/html'});
+        }
+
+        var blob = this.blank ? (new Blob([this.blank], {type: 'text/html'})) : $p.injected_data['view_blank.html'];
+
+        var doc = this,
+          url = window.URL.createObjectURL(blob),
+          wnd_print = window.open(
+          url, "_blank", "fullscreen,menubar=no,toolbar=no,location=no,status=no,directories=no,resizable=yes,scrollbars=yes");
+
+        if (wnd_print.outerWidth < screen.availWidth || wnd_print.outerHeight < screen.availHeight){
+          wnd_print.moveTo(0,0);
+          wnd_print.resizeTo(screen.availWidth, screen.availHeight);
+        }
+
+        wnd_print.onload = function(e) {
+          window.URL.revokeObjectURL(url);
+          // копируем элементы из head
+          for (var i = 0; i < doc.head.children.length; i++) {
+            wnd_print.document.head.appendChild(doc.copy_element(doc.head.children[i]));
+          }
+          // копируем элементы из content
+          for (var i = 0; i < doc.content.children.length; i++) {
+            wnd_print.document.body.appendChild(doc.copy_element(doc.content.children[i]));
+          }
+          if(doc.title){
+            wnd_print.document.title = doc.title;
+          }
+
+          // сохраняем содержимое документа
+          var blob = new Blob([wnd_print.document.firstElementChild.outerHTML], { type: 'text/html' });
+          if (window.navigator.msSaveOrOpenBlob) {
+            window.navigator.msSaveBlob(blob, filename);
+          } else {
+            var elem = window.document.createElement('a');
+            elem.href = window.URL.createObjectURL(blob);
+            elem.download = filename;
+            document.body.appendChild(elem);
+            elem.click();
+            document.body.removeChild(elem);
+          }
+
+          wnd_print.close();
+          doc = null;
+        };
+
+        return null;
+      }
+      catch(err){
+        window.URL.revokeObjectURL && window.URL.revokeObjectURL(url);
+        $p.msg.show_msg({
+          title: $p.msg.bld_title,
+          type: "alert-error",
+          text: err.message.match("outerWidth") ?
+            "Ошибка сохранения документа" : err.message
+        });
+      }
+    }
+  },
+
+  blank: {
+    get: function () {
+      return this._attr.blank
+    },
+    set: function (v) {
+      this._attr.blank = v;
+    }
+  },
+
+  head: {
+    get: function () {
+      return this._attr.head
+    },
+    set: function (v) {
+
+      this.clear_head();
+
+      if(typeof v == "string")
+        this._attr.head.innerHTML = v;
+      
+      else if(v instanceof HTMLElement)
+        this._attr.head.innerHTML = v.innerHTML;
     }
   },
 

--- a/src/reporting.js
+++ b/src/reporting.js
@@ -18,7 +18,7 @@ function SpreadsheetDocument(attr, events) {
 		orientation: "portrait",
     blank: "",
     head: document.createElement("HEAD"),
-    content: document.createElement("BODY"),
+    content: document.createElement("DIV"),
     title: ""
 	};
 
@@ -307,8 +307,12 @@ SpreadsheetDocument.prototype.__define({
             wnd_print.document.head.appendChild(doc.copy_element(doc.head.children[i]));
           }
           // копируем элементы из content
-          for (var i = 0; i < doc.content.children.length; i++) {
-            wnd_print.document.body.appendChild(doc.copy_element(doc.content.children[i]));
+          if (doc.innerContent) {
+            for (var i = 0; i < doc.content.children.length; i++) {
+              wnd_print.document.body.appendChild(doc.copy_element(doc.content.children[i]));
+            }
+          } else {
+            wnd_print.document.body.appendChild(doc.content);
           }
           if(doc.title){
             wnd_print.document.title = doc.title;
@@ -362,8 +366,12 @@ SpreadsheetDocument.prototype.__define({
             wnd_print.document.head.appendChild(doc.copy_element(doc.head.children[i]));
           }
           // копируем элементы из content
-          for (var i = 0; i < doc.content.children.length; i++) {
-            wnd_print.document.body.appendChild(doc.copy_element(doc.content.children[i]));
+          if (doc.innerContent) {
+            for (var i = 0; i < doc.content.children.length; i++) {
+              wnd_print.document.body.appendChild(doc.copy_element(doc.content.children[i]));
+            }
+          } else {
+            wnd_print.document.body.appendChild(doc.content);
           }
           if(doc.title){
             wnd_print.document.title = doc.title;


### PR DESCRIPTION
Существующая схема работы конструктора отчетов не была изменена, за исключением некоторых моментов:
1. `_attr.content` стал тегом `BODY`, содержимое которого, в `print` и `save_as`, копируется в тело документа. Ранее `_attr.content` был `DIV` и помещался в тело документа как `DIV`, а не как содержимое тега. При использовании некоторых схем разметки отчетов, этот `DIV` мешает;
2. В методе `put`, при копировании атрибутов, не учитывался `id`, иногда этот атрибут нужен, игнорирование убрал.

Новые возможности:
1. возможность задавать бланк документа, в противном случае используется по умолчанию `$p.injected_data['view_blank.html']`;
2. возможность задавать заголовок документа `head`. Добавление тегов через метод `put_head`;
3. метод сохранения документа в файл `save_as`.