### PR TITLE
исправление получения фильтра из графического интерфейса

### DIFF
--- a/src/widgets/toolbar_filter.js
+++ b/src/widgets/toolbar_filter.js
@@ -188,8 +188,8 @@ $p.iface.Toolbar_filter.prototype.__define({
       }
 
 			var res = {
-				date_from: this.input_date_from ? $p.utils.date_add_day(dhx4.str2date(this.input_date_from.value), 0, true) : "",
-				date_till: this.input_date_till ? $p.utils.date_add_day(dhx4.str2date(this.input_date_till.value), 0, true) : "",
+				date_from: this.input_date_from && this.input_date_from.value ? $p.utils.date_add_day(dhx4.str2date(this.input_date_from.value), 0, true) : new Date(),
+				date_till: this.input_date_till && this.input_date_till.value ? $p.utils.date_add_day(dhx4.str2date(this.input_date_till.value), 0, true) : new Date(),
 				filter: this.input_filter ? this.input_filter.value : ""
 			}, fld, flt;
 


### PR DESCRIPTION
Если в элементах интерфейса временного интервала пустые значения, вызов функции `$p.utils.date_add_day` порождает ошибку, т.к. `dhx4.str2date` возвращает `Invalid date`.

Если `date_from` или `date_till` являются пустой строкой, также вызывает ошибку, должны быть объектом `Date`.