### PR TITLE
исправление если колбэк возвращает истину

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -501,8 +501,11 @@ function MetaEngine() {
 					// выполняем колбэк с элементом и пополняем итоговый массив
 					if($p._selection.call(this, o, selection)){
 						if(callback){
-							if(callback.call(this, o) === false)
+							if(callback.call(this, o)){
+								res.push(o);
+							}else{
 								break;
+							}
 						}else
 							res.push(o);
 


### PR DESCRIPTION
При использовании метода `find_rows`, если передать в качестве фильтра колбэк и он возвращает имстину, что означает элемент должен добавиться в массив результата, это не происходит.