### PR TITLE
исправление начального рендера поля для поиска

### DIFF
--- a/packages/metadata-react/src/SchemeSettings/SearchBox.js
+++ b/packages/metadata-react/src/SchemeSettings/SearchBox.js
@@ -89,7 +89,7 @@ class SearchBox extends React.Component {
         <input
           className={classes.input}
           placeholder="Поиск..."
-          value={scheme._search}
+          value={scheme._search ? scheme._search : ""}
           onChange={this.handleChange}
           onKeyDown={this.handleKeyDown}
         />


### PR DESCRIPTION
Ловлю ошибку в `CalcOrderList`. При первоначальном рендере компонента поля `_search` в схеме данных не существует и в свойство компонента `value` передается `undefined`, а нужно передать пустую строку.

Если трудно согласиться с предложенным и нужно описать как воспроизвести, сообщите.