### PR TITLE
исправление поведения диалога с disablePortal

### DIFF
--- a/packages/metadata-react/src/App/Dialog.js
+++ b/packages/metadata-react/src/App/Dialog.js
@@ -75,7 +75,6 @@ class SimpleDialog extends React.Component {
     const {open, fullScreen, noSpace, title, actions, children, classes, onClose, minheight, large} = this.props;
     const stateFullScreen = fullScreen || this.state.fullScreen;
     return <Dialog
-      disablePortal
       open={open}
       fullScreen={stateFullScreen}
       onClose={onClose}


### PR DESCRIPTION
Со свойством `disablePortal: true` диалог остается в родительской иерархии DOM, в нашем случае внутри `Downshift`, который в свою очередь внутри ячейки табчасти `FieldInfinit`. В результате его не видно, точнее видна его часть.