### PR TITLE
поддержка ввода числовых значений с запятой

### DIFF
--- a/packages/metadata-react/src/DataField/FieldNumber.js
+++ b/packages/metadata-react/src/DataField/FieldNumber.js
@@ -22,7 +22,8 @@ class FieldNumber extends AbstractField {
 
   onChange = (event) => {
     const {_obj, _fld, handleValueChange} = this.props;
-    const {value} = event.target;
+    let {value} = event.target;
+    value = value.replace(/,/g, '.');
     _obj[_fld] = value;
     this.setState({value}, () => handleValueChange && handleValueChange(value));
   };


### PR DESCRIPTION
Если вводить числа с точкой, дробная часть не теряется, если с запятой, дробная часть становится нулевой.