### PR TITLE
RSD-819 Скрыть возможность настройки отчетов для "обычных пользователей"

### DIFF
--- a/packages/metadata-react/src/FrmReport/RepToolbar.js
+++ b/packages/metadata-react/src/FrmReport/RepToolbar.js
@@ -58,7 +58,7 @@ class RepToolbar extends Component {
   render() {
 
     const {props, state, handleChange} = this;
-    const {handleSave, handleClose, handlePrint, _obj, _tabular, classes, scheme, settings_open, ToolbarExt} = props;
+    const {handleSave, handleClose, handlePrint, _obj, _tabular, classes, scheme, settings_open, ToolbarExt, hide_btn} = props;
 
 
     return (
@@ -87,6 +87,7 @@ class RepToolbar extends Component {
           classes={classes}
           scheme={scheme}
           show_variants={true}
+          hide_btn={hide_btn}
         />
 
         <IconButton onClick={this.handleMenuOpen} title="Дополнительно">

--- a/packages/metadata-react/src/FrmReport/Report.js
+++ b/packages/metadata-react/src/FrmReport/Report.js
@@ -135,6 +135,7 @@ export class Report extends MDNRComponent {
         handleSave={this.handleSave}
         handlePrint={this.handlePrint}
         handleClose={this.handleClose}
+        hide_btn={props.hide_btn}
       />,
 
       settings_open && <SchemeSettingsTabs


### PR DESCRIPTION
Прокинул опцию для скрытия кнопки настроек Спецификации до верхнего уровня.